### PR TITLE
Feature: Implement MCP Completion (prompt argument only), add tests and examples

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/trpc-mcp-go.iml" filepath="$PROJECT_DIR$/.idea/trpc-mcp-go.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/trpc-mcp-go.iml
+++ b/.idea/trpc-mcp-go.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/completion_prompt_test.go
+++ b/completion_prompt_test.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletionComplete_Prompt_Success(t *testing.T) {
+	handler := newMCPHandler()
+
+	prompt := &Prompt{
+		Name:        "test-prompt",
+		Description: "测试补全prompt",
+		Arguments: []PromptArgument{
+			{Name: "input", Description: "输入", Required: false},
+		},
+	}
+	completionHandler := func(ctx context.Context, req *CompletionCompleteRequest) (*CompletionCompleteResult, error) {
+		input := req.Params.Argument["input"]
+		var suggestions []string
+		if input == "he" {
+			suggestions = []string{"hello", "help"}
+		} else {
+			suggestions = []string{"default"}
+		}
+		return &CompletionCompleteResult{
+			Completion: Completion{
+				Values:  suggestions,
+				Total:   len(suggestions),
+				HasMore: false,
+			},
+		}, nil
+	}
+	handler.promptManager.registerPromptWithCompletion(prompt, nil, completionHandler)
+
+	req := newJSONRPCRequest(1, MethodCompletionComplete, map[string]interface{}{
+		"ref": map[string]interface{}{
+			"type": "ref/prompt",
+			"name": "test-prompt",
+		},
+		"argument": map[string]interface{}{
+			"input": "he",
+		},
+	})
+	ctx := context.Background()
+	resp, err := handler.handleRequest(ctx, req, newSession())
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	t.Logf("resp type: %T", resp)
+	result, ok := resp.(*CompletionCompleteResult)
+	assert.True(t, ok)
+	assert.Equal(t, []string{"hello", "help"}, result.Completion.Values)
+	assert.Equal(t, 2, result.Completion.Total)
+	assert.False(t, result.Completion.HasMore)
+}
+
+func TestCompletionComplete_Prompt_NotFound(t *testing.T) {
+	handler := newMCPHandler()
+
+	req := newJSONRPCRequest(1, MethodCompletionComplete, map[string]interface{}{
+		"ref": map[string]interface{}{
+			"type": "ref/prompt",
+			"name": "not-exist",
+		},
+		"argument": map[string]interface{}{},
+	})
+	ctx := context.Background()
+	resp, err := handler.handleRequest(ctx, req, newSession())
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	errResp, ok := resp.(*JSONRPCError)
+	assert.True(t, ok)
+	assert.Contains(t, errResp.Error.Message, "prompt not found")
+}
+
+func TestCompletionComplete_Prompt_NoCompletionHandler(t *testing.T) {
+	handler := newMCPHandler()
+	prompt := &Prompt{
+		Name:        "no-completion",
+		Description: "无补全handler",
+	}
+	handler.promptManager.registerPrompt(prompt, nil)
+
+	req := newJSONRPCRequest(1, MethodCompletionComplete, map[string]interface{}{
+		"ref": map[string]interface{}{
+			"type": "ref/prompt",
+			"name": "no-completion",
+		},
+		"argument": map[string]interface{}{},
+	})
+	ctx := context.Background()
+	resp, err := handler.handleRequest(ctx, req, newSession())
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	result, ok := resp.(*CompletionCompleteResult)
+	assert.True(t, ok)
+	assert.Empty(t, result.Completion.Values)
+	assert.Equal(t, 0, result.Completion.Total)
+	assert.False(t, result.Completion.HasMore)
+}

--- a/examples/completion_example/client/main.go
+++ b/examples/completion_example/client/main.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	mcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+func main() {
+	// 创建上下文
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// 创建客户端信息
+	clientInfo := mcp.Implementation{
+		Name:    "Completion-Example-Client",
+		Version: "1.0.0",
+	}
+
+	// 创建客户端
+	mcpClient, err := mcp.NewClient(
+		"http://localhost:3000/mcp",
+		clientInfo,
+	)
+	if err != nil {
+		log.Fatalf("Failed to create client: %v", err)
+	}
+	defer mcpClient.Close()
+
+	// 初始化客户端
+	log.Printf("Initializing client...")
+	initResp, err := mcpClient.Initialize(ctx, &mcp.InitializeRequest{})
+	if err != nil {
+		log.Fatalf("Initialization failed: %v", err)
+	}
+
+	log.Printf("Initialization succeeded: Server=%s %s, Protocol=%s",
+		initResp.ServerInfo.Name, initResp.ServerInfo.Version, initResp.ProtocolVersion)
+	log.Printf("Server capabilities: %+v", initResp.Capabilities)
+
+	// 检查服务器是否支持 completions
+	if initResp.Capabilities.Completions == nil {
+		log.Println("Warning: Server does not support completions")
+		return
+	}
+
+	log.Println("Server supports completions!")
+
+	// 列出所有 prompts
+	log.Printf("Listing prompts...")
+	promptsResp, err := mcpClient.ListPrompts(ctx, &mcp.ListPromptsRequest{})
+	if err != nil {
+		log.Fatalf("Failed to list prompts: %v", err)
+	}
+
+	log.Printf("Server provides %d prompts", len(promptsResp.Prompts))
+	for _, prompt := range promptsResp.Prompts {
+		log.Printf("- Prompt: %s (%s)", prompt.Name, prompt.Description)
+	}
+
+	// 测试语言参数的 completion
+	log.Println("\n=== Testing language completion ===")
+
+	// 测试 "py" 前缀
+	testCompletion(ctx, mcpClient, "code_review", "language", "py")
+
+	// 测试 "ja" 前缀
+	testCompletion(ctx, mcpClient, "code_review", "language", "ja")
+
+	// 测试 "go" 前缀
+	testCompletion(ctx, mcpClient, "code_review", "language", "go")
+
+	// 测试框架参数的 completion
+	log.Println("\n=== Testing framework completion ===")
+
+	// 测试 Python 框架
+	testCompletion(ctx, mcpClient, "code_review", "framework", "fl")
+
+	// 测试 JavaScript 框架
+	testCompletion(ctx, mcpClient, "code_review", "framework", "re")
+
+	// 测试获取 prompt
+	log.Println("\n=== Testing prompt retrieval ===")
+	promptResp, err := mcpClient.GetPrompt(ctx, &mcp.GetPromptRequest{
+		Params: struct {
+			Name      string            `json:"name"`
+			Arguments map[string]string `json:"arguments,omitempty"`
+		}{
+			Name: "code_review",
+			Arguments: map[string]string{
+				"language":  "python",
+				"framework": "django",
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("Failed to get prompt: %v", err)
+	}
+
+	log.Printf("Prompt description: %s", promptResp.Description)
+	log.Printf("Prompt messages: %d", len(promptResp.Messages))
+	for i, msg := range promptResp.Messages {
+		if textContent, ok := msg.Content.(mcp.TextContent); ok {
+			log.Printf("Message %d: %s", i+1, textContent.Text)
+		}
+	}
+
+	log.Printf("Client example finished, exiting in 3 seconds...")
+	time.Sleep(3 * time.Second)
+}
+
+// testCompletion 测试基本的 completion 功能
+func testCompletion(ctx context.Context, client *mcp.Client, promptName, argumentName, argumentValue string) {
+	log.Printf("Testing completion for %s.%s = '%s'", promptName, argumentName, argumentValue)
+
+	// 构建 completion 请求
+	req := &mcp.CompletionCompleteRequest{
+		Params: struct {
+			Ref      map[string]string `json:"ref"`
+			Argument map[string]string `json:"argument"`
+		}{
+			Ref: map[string]string{
+				"type": "ref/prompt",
+				"name": promptName,
+			},
+			Argument: map[string]string{
+				"name":  argumentName,
+				"value": argumentValue,
+			},
+		},
+	}
+
+	// 发送请求
+	resp, err := client.CompletionComplete(ctx, req)
+	if err != nil {
+		log.Printf("Completion failed: %v", err)
+		return
+	}
+
+	log.Printf("Completion results:")
+	log.Printf("  Values: %v", resp.Completion.Values)
+	log.Printf("  Total: %d", resp.Completion.Total)
+	log.Printf("  HasMore: %t", resp.Completion.HasMore)
+}

--- a/examples/completion_example/server/main.go
+++ b/examples/completion_example/server/main.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	mcp "trpc.group/trpc-go/trpc-mcp-go"
+)
+
+func main() {
+	// 创建 MCP 服务器
+	server := mcp.NewServer("Completion Example Server", "1.0.0")
+
+	// 定义编程语言列表
+	languages := []string{"python", "javascript", "go", "java", "c++", "rust", "typescript", "php", "ruby", "swift"}
+
+	// 定义框架映射
+	frameworks := map[string][]string{
+		"python":     {"django", "flask", "fastapi", "pytorch", "tensorflow"},
+		"javascript": {"react", "vue", "angular", "express", "next.js"},
+		"go":         {"gin", "echo", "fiber", "chi", "gorilla"},
+		"java":       {"spring", "hibernate", "struts", "play", "quarkus"},
+		"c++":        {"qt", "boost", "stl", "opencv", "eigen"},
+		"rust":       {"actix", "rocket", "axum", "tokio", "serde"},
+		"typescript": {"react", "vue", "angular", "express", "next.js"},
+		"php":        {"laravel", "symfony", "codeigniter", "yii", "slim"},
+		"ruby":       {"rails", "sinatra", "hanami", "grape", "padrino"},
+		"swift":      {"swiftui", "uikit", "combine", "alamofire", "kingfisher"},
+	}
+
+	// 注册带有 completion handler 的 prompt
+	server.RegisterPromptWithCompletion(
+		&mcp.Prompt{
+			Name:        "code_review",
+			Description: "Generate a code review for the specified language and framework",
+			Arguments: []mcp.PromptArgument{
+				{
+					Name:        "language",
+					Description: "Programming language",
+					Required:    true,
+				},
+				{
+					Name:        "framework",
+					Description: "Framework for the language",
+					Required:    false,
+				},
+			},
+		},
+		// Prompt handler
+		func(ctx context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+			language := req.Params.Arguments["language"]
+			framework := req.Params.Arguments["framework"]
+
+			description := fmt.Sprintf("Code review for %s", language)
+			if framework != "" {
+				description += fmt.Sprintf(" with %s framework", framework)
+			}
+
+			messages := []mcp.PromptMessage{
+				{
+					Role: mcp.RoleUser,
+					Content: mcp.TextContent{
+						Type: "text",
+						Text: fmt.Sprintf("Please provide a comprehensive code review for %s code%s. Focus on best practices, performance, security, and maintainability.",
+							language,
+							func() string {
+								if framework != "" {
+									return fmt.Sprintf(" using %s framework", framework)
+								}
+								return ""
+							}()),
+					},
+				},
+			}
+
+			return &mcp.GetPromptResult{
+				Description: description,
+				Messages:    messages,
+			}, nil
+		},
+		// Completion handler
+		func(ctx context.Context, req *mcp.CompletionCompleteRequest) (*mcp.CompletionCompleteResult, error) {
+			argumentName := req.Params.Argument["name"]
+			argumentValue := req.Params.Argument["value"]
+
+			var suggestions []string
+			var total int
+			var hasMore bool
+
+			switch argumentName {
+			case "language":
+				// 为语言参数提供建议
+				value := strings.ToLower(argumentValue)
+				for _, lang := range languages {
+					if strings.HasPrefix(strings.ToLower(lang), value) {
+						suggestions = append(suggestions, lang)
+					}
+				}
+				total = len(suggestions)
+				hasMore = false
+
+			case "framework":
+				// 为框架参数提供建议（简化版本，不依赖上下文）
+				value := strings.ToLower(argumentValue)
+				// 为所有语言的框架提供建议
+				for _, frameworksForLang := range frameworks {
+					for _, framework := range frameworksForLang {
+						if strings.HasPrefix(strings.ToLower(framework), value) {
+							suggestions = append(suggestions, framework)
+						}
+					}
+				}
+				total = len(suggestions)
+				hasMore = false
+			}
+
+			// 限制返回的建议数量
+			if len(suggestions) > 100 {
+				suggestions = suggestions[:100]
+			}
+
+			return &mcp.CompletionCompleteResult{
+				Completion: mcp.Completion{
+					Values:  suggestions,
+					Total:   total,
+					HasMore: hasMore,
+				},
+			}, nil
+		},
+	)
+
+	// 启动服务器
+	log.Println("Starting completion example server on localhost:3000")
+	log.Println("Server supports the following capabilities:")
+	log.Println("- Prompts with completion suggestions")
+	log.Println("- Language and framework autocompletion")
+
+	if err := server.Start(); err != nil {
+		log.Fatal("Server failed to start:", err)
+	}
+}

--- a/manager_lifecycle.go
+++ b/manager_lifecycle.go
@@ -134,6 +134,10 @@ func (m *lifecycleManager) updateCapabilities() {
 		capMap["prompts"] = map[string]interface{}{
 			"listChanged": true,
 		}
+		// Add completions capability if any prompt has completion handler
+		if m.promptManager.hasCompletionHandlers() {
+			capMap["completions"] = map[string]interface{}{}
+		}
 	}
 
 	// Preserve existing experimental features

--- a/mcp_prompts.go
+++ b/mcp_prompts.go
@@ -12,13 +12,17 @@ import (
 	"fmt"
 )
 
+// completionHandler defines the function type for handling completion requests
+type completionHandler func(ctx context.Context, req *CompletionCompleteRequest) (*CompletionCompleteResult, error)
+
 // promptHandler defines the function type for handling prompt requests
 type promptHandler func(ctx context.Context, req *GetPromptRequest) (*GetPromptResult, error)
 
 // registeredPrompt combines a Prompt with its handler function
 type registeredPrompt struct {
-	Prompt  *Prompt
-	Handler promptHandler
+	Prompt            *Prompt
+	Handler           promptHandler
+	CompletionHandler completionHandler
 }
 
 // ListPromptsRequest describes a request to list prompts.
@@ -46,6 +50,28 @@ type GetPromptResult struct {
 	Result
 	Description string          `json:"description,omitempty"`
 	Messages    []PromptMessage `json:"messages"`
+}
+
+// CompletionCompleteRequest describes a request to complete a prompt or resource.
+type CompletionCompleteRequest struct {
+	Request
+	Params struct {
+		Ref      map[string]string `json:"ref"`
+		Argument map[string]string `json:"argument"`
+	} `json:"params"`
+}
+
+// CompletionCompleteResult describes a result complete a prompt or resource.
+type CompletionCompleteResult struct {
+	Result
+	Completion Completion `json:"completion"`
+}
+
+// Completion describes the completion of a prompt or resource.
+type Completion struct {
+	Values  []string `json:"values"`
+	Total   int      `json:"total"`
+	HasMore bool     `json:"hasMore"`
 }
 
 // PromptListChangedNotification represents a notification that the prompt list has changed

--- a/server.go
+++ b/server.go
@@ -324,6 +324,14 @@ func (s *Server) RegisterPrompt(prompt *Prompt, handler promptHandler) {
 	s.promptManager.registerPrompt(prompt, handler)
 }
 
+// RegisterPromptWithCompletion registers a prompt with both handler and completion handler functions
+//
+// This method allows you to register a prompt that supports both prompt rendering
+// and argument completion suggestions.
+func (s *Server) RegisterPromptWithCompletion(prompt *Prompt, handler promptHandler, completionHandler completionHandler) {
+	s.promptManager.registerPromptWithCompletion(prompt, handler, completionHandler)
+}
+
 // SendNotification sends a notification to a specific session
 func (s *Server) SendNotification(sessionID string, method string, params map[string]interface{}) error {
 	// Create a notification object

--- a/utils_json.go
+++ b/utils_json.go
@@ -41,6 +41,15 @@ func parseGetPromptResultFromJSON(rawMessage *json.RawMessage) (*GetPromptResult
 	return &result, nil
 }
 
+// parseCompletionCompleteResultFromJSON parses a raw JSON message into a CompletionCompleteResult
+func parseCompletionCompleteResultFromJSON(rawMessage *json.RawMessage) (*CompletionCompleteResult, error) {
+	var result CompletionCompleteResult
+	if err := json.Unmarshal(*rawMessage, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal CompletionCompleteResult: %v", err)
+	}
+	return &result, nil
+}
+
 // parseListResourcesResultFromJSON parses a raw JSON message into a ListResourcesResult
 func parseListResourcesResultFromJSON(rawMessage *json.RawMessage) (*ListResourcesResult, error) {
 	var result ListResourcesResult


### PR DESCRIPTION
Implements 【腾讯犀牛鸟计划】tRPC-MCP-Go Completion功能 #19
This pull request partially addresses Issue #19.
Main changes:
• Add support for the completion/complete method, enabling intelligent completion suggestions for prompt arguments (ref/prompt type).
• Extend the core client (client.go) to support the CompletionComplete method.
• Enhance manager_prompt.go and mcp_prompts.go to handle completion requests and define related data structures.
• Add RegisterPromptWithCompletion to the server, allowing registration of prompts with completion handlers.
• Add comprehensive unit tests in completion_prompt_test.go to cover normal, error, and fallback scenarios for prompt completion.
• Provide full client and server examples (examples/completion_example/) demonstrating how to use the completion feature in real applications.
• Minor updates to lifecycle, utils, and server integration to support the new feature.
Note:
This PR implements intelligent completion for prompt arguments only. Resource URI completion is not included in this update.
Next Steps:
The resource URI completion functionality will be delivered in a follow-up PR, completing the full scope of Issue #19.