### PR TITLE
fix: Resource arguments not passed to handler

### DIFF
--- a/manager_resource.go
+++ b/manager_resource.go
@@ -299,6 +299,13 @@ func (m *resourceManager) handleReadResource(ctx context.Context, req *JSONRPCRe
 		},
 	}
 
+	// Extract and set arguments if present.
+	if args, ok := paramsMap["arguments"]; ok && args != nil {
+		if argsMap, ok := args.(map[string]interface{}); ok {
+			readReq.Params.Arguments = argsMap
+		}
+	}
+
 	// Call resource handler
 	contents, err := registeredResource.Handler(ctx, readReq)
 	if err != nil {


### PR DESCRIPTION
- Fix handleReadResource function in manager_resource.go
- Add missing arguments extraction from request params
- Arguments were being ignored when creating ReadResourceRequest
- Now properly extracts and sets arguments for resource handlers
- Matches the same logic used in manager_tools.go for consistency
- Fixes issue where resource handlers received nil arguments