### PR TITLE
fix: report tool execution errors via CallToolResult isError

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
+    if result.IsError {
+        log.Fatalf("tool failed: %v", result.Content)
+    }
     
     fmt.Printf("Result: %v\n", result.Content[0])
 }

--- a/e2e/scenarios/basic_test.go
+++ b/e2e/scenarios/basic_test.go
@@ -78,11 +78,17 @@ func TestErrorHandling(t *testing.T) {
 		callToolReq.Params.Arguments = map[string]interface{}{
 			"error_message": errorMsg,
 		}
-		_, err := client.CallTool(ctx, callToolReq)
+		result, err := client.CallTool(ctx, callToolReq)
 
-		// Verify error.
-		require.Error(t, err, "Should return error")
-		assert.Contains(t, err.Error(), errorMsg, "Error message should contain the provided error message")
+		// Verify tool execution error is returned in the tool result.
+		require.NoError(t, err, "tool execution errors should stay in CallToolResult")
+		require.NotNil(t, result)
+		assert.True(t, result.IsError, "tool result should be marked as error")
+		require.Len(t, result.Content, 1)
+
+		textContent, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok, "Content should be of type TextContent")
+		assert.Contains(t, textContent.Text, errorMsg, "Error content should contain the provided error message")
 	})
 }
 

--- a/e2e/stdio_integration_test.go
+++ b/e2e/stdio_integration_test.go
@@ -137,7 +137,7 @@ func TestStdioClientServer_EndToEndIntegration(t *testing.T) {
 		assert.Error(t, err, "Should error when calling non-existent tool")
 
 		// Test invalid parameters
-		_, err = client.CallTool(ctx, &mcp.CallToolRequest{
+		result, err := client.CallTool(ctx, &mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
 				Name:      "echo",
 				Arguments: map[string]interface{}{
@@ -145,7 +145,14 @@ func TestStdioClientServer_EndToEndIntegration(t *testing.T) {
 				},
 			},
 		})
-		assert.Error(t, err, "Should error with missing required parameters")
+		require.NoError(t, err, "tool execution errors should stay in CallToolResult")
+		require.NotNil(t, result)
+		assert.True(t, result.IsError, "missing business parameters should be reported as tool errors")
+		require.Len(t, result.Content, 1)
+
+		textContent, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok)
+		assert.Contains(t, textContent.Text, "missing 'text' parameter")
 	})
 
 	// === Test Client State ===

--- a/examples/annotations/client/main.go
+++ b/examples/annotations/client/main.go
@@ -128,6 +128,9 @@ func handleTools(ctx context.Context, client *mcp.Client) error {
 	if err != nil {
 		return fmt.Errorf("failed to call tool: %v", err)
 	}
+	if callToolResp.IsError {
+		return fmt.Errorf("tool returned error result: %v", callToolResp.Content)
+	}
 
 	log.Printf("Tool result:")
 	for _, item := range callToolResp.Content {

--- a/examples/quickstart/client/main.go
+++ b/examples/quickstart/client/main.go
@@ -119,6 +119,9 @@ func handleTools(ctx context.Context, client *mcp.Client) error {
 	if err != nil {
 		return fmt.Errorf("failed to call tool: %v", err)
 	}
+	if callToolResp.IsError {
+		return fmt.Errorf("tool returned error result: %v", callToolResp.Content)
+	}
 
 	log.Printf("Tool result:")
 	for _, item := range callToolResp.Content {

--- a/examples/transport-modes/streamable-http/stateful-sse-getsse/server/main.go
+++ b/examples/transport-modes/streamable-http/stateful-sse-getsse/server/main.go
@@ -304,11 +304,9 @@ func handleCounter(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallTool
 	// Get session from context
 	session, ok := mcp.GetSessionFromContext(ctx)
 	if !ok || session == nil {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.NewTextContent("Error: Unable to get session information. This tool requires a stateful session to work."),
-			},
-		}, fmt.Errorf("unable to get session from context")
+		return mcp.NewErrorResult(
+			"Error: Unable to get session information. This tool requires a stateful session to work.",
+		), nil
 	}
 
 	// Get counter from session data
@@ -345,24 +343,18 @@ func handleDelayedResponse(ctx context.Context, req *mcp.CallToolRequest) (*mcp.
 	// Get session from context
 	session, ok := mcp.GetSessionFromContext(ctx)
 	if !ok || session == nil {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.NewTextContent("Error: Unable to get session information. This tool requires a stateful session to work."),
-			},
-		}, fmt.Errorf("unable to get session from context")
+		return mcp.NewErrorResult(
+			"Error: Unable to get session information. This tool requires a stateful session to work.",
+		), nil
 	}
 
 	// Get notification sender from context
 	notificationSender, ok := mcp.GetNotificationSender(ctx)
 	if !ok {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.NewTextContent(
-					"Error: Unable to get notification sender. " +
-						"This feature requires SSE streaming response support.",
-				),
-			},
-		}, fmt.Errorf("unable to get notification sender from context")
+		return mcp.NewErrorResult(
+			"Error: Unable to get notification sender. " +
+				"This feature requires SSE streaming response support.",
+		), nil
 	}
 
 	// Get steps and delay from parameters
@@ -393,11 +385,7 @@ func handleDelayedResponse(ctx context.Context, req *mcp.CallToolRequest) (*mcp.
 		// Check if context is cancelled
 		select {
 		case <-ctx.Done():
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{
-					mcp.NewTextContent(fmt.Sprintf("Processing cancelled at step %d", i)),
-				},
-			}, ctx.Err()
+			return nil, ctx.Err()
 		default:
 			// Continue execution
 		}
@@ -450,11 +438,9 @@ func handleNotification(ctx context.Context, req *mcp.CallToolRequest) (*mcp.Cal
 	// Get session from context
 	session, ok := mcp.GetSessionFromContext(ctx)
 	if !ok || session == nil {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.NewTextContent("Error: Unable to get session information. This tool requires a stateful session to work."),
-			},
-		}, fmt.Errorf("unable to get session from context")
+		return mcp.NewErrorResult(
+			"Error: Unable to get session information. This tool requires a stateful session to work.",
+		), nil
 	}
 
 	// Get message and delay time from parameters
@@ -511,11 +497,9 @@ func handleChatJoin(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToo
 	// Get session from context
 	session, ok := mcp.GetSessionFromContext(ctx)
 	if !ok || session == nil {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.NewTextContent("Error: Unable to get session information. This tool requires a stateful session to work."),
-			},
-		}, fmt.Errorf("unable to get session from context")
+		return mcp.NewErrorResult(
+			"Error: Unable to get session information. This tool requires a stateful session to work.",
+		), nil
 	}
 
 	// Get username from parameters
@@ -566,11 +550,9 @@ func handleChatSend(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToo
 	// Get session from context
 	session, ok := mcp.GetSessionFromContext(ctx)
 	if !ok || session == nil {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.NewTextContent("Error: Unable to get session information. This tool requires a stateful session to work."),
-			},
-		}, fmt.Errorf("unable to get session from context")
+		return mcp.NewErrorResult(
+			"Error: Unable to get session information. This tool requires a stateful session to work.",
+		), nil
 	}
 
 	// Get username
@@ -589,11 +571,7 @@ func handleChatSend(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToo
 
 	// If still no username, please join the chat room first
 	if userName == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.NewTextContent("Error: Please use chatJoin tool to join the chat room first."),
-			},
-		}, nil
+		return mcp.NewErrorResult("Error: Please use chatJoin tool to join the chat room first."), nil
 	}
 
 	// Get message from parameters
@@ -606,11 +584,7 @@ func handleChatSend(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToo
 
 	// Validate message is not empty
 	if message == "" {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				mcp.NewTextContent("Error: Message cannot be empty."),
-			},
-		}, nil
+		return mcp.NewErrorResult("Error: Message cannot be empty."), nil
 	}
 
 	// Add message to chat history

--- a/manager_tools.go
+++ b/manager_tools.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"sync"
 
-	"trpc.group/trpc-go/trpc-mcp-go/internal/errors"
+	stderrors "errors"
+
+	mcpErrors "trpc.group/trpc-go/trpc-mcp-go/internal/errors"
 )
 
 // serverProvider interface defines components that can provide server instances
@@ -192,13 +194,13 @@ func (m *toolManager) handleCallTool(
 ) (JSONRPCMessage, error) {
 	// Parse request parameters
 	if req.Params == nil {
-		return newJSONRPCErrorResponse(req.ID, ErrCodeInvalidParams, errors.ErrMissingParams.Error(), nil), nil
+		return newJSONRPCErrorResponse(req.ID, ErrCodeInvalidParams, mcpErrors.ErrMissingParams.Error(), nil), nil
 	}
 
 	// Convert params to map for easier access
 	paramsMap, ok := req.Params.(map[string]interface{})
 	if !ok {
-		return newJSONRPCErrorResponse(req.ID, ErrCodeInvalidParams, errors.ErrInvalidParams.Error(), nil), nil
+		return newJSONRPCErrorResponse(req.ID, ErrCodeInvalidParams, mcpErrors.ErrInvalidParams.Error(), nil), nil
 	}
 
 	// Get tool name
@@ -216,7 +218,7 @@ func (m *toolManager) handleCallTool(
 		return newJSONRPCErrorResponse(
 			req.ID,
 			ErrCodeMethodNotFound,
-			fmt.Sprintf("%v: %s", errors.ErrToolNotFound, toolName),
+			fmt.Sprintf("%v: %s", mcpErrors.ErrToolNotFound, toolName),
 			nil,
 		), nil
 	}
@@ -234,7 +236,7 @@ func (m *toolManager) handleCallTool(
 	if args, ok := paramsMap["arguments"]; ok && args != nil {
 		argsMap, ok := args.(map[string]interface{})
 		if !ok {
-			errMsg := fmt.Sprintf("%v: arguments must be an object, got %T", errors.ErrInvalidParams, args)
+			errMsg := fmt.Sprintf("%v: arguments must be an object, got %T", mcpErrors.ErrInvalidParams, args)
 			return newJSONRPCErrorResponse(req.ID, ErrCodeInvalidParams, errMsg, nil), nil
 		}
 		params.Arguments = argsMap
@@ -267,9 +269,28 @@ func (m *toolManager) handleCallTool(
 	// Execute tool
 	result, err := registeredTool.Handler(ctx, toolReq)
 	if err != nil {
-		errMsg := fmt.Sprintf("tool execution failed (tool: %s): %v", registeredTool.Tool.Name, err)
-		return newJSONRPCErrorResponse(req.ID, ErrCodeInternal, errMsg, nil), nil
+		if isExceptionalToolError(err) {
+			errMsg := fmt.Sprintf("tool execution failed (tool: %s): %v", registeredTool.Tool.Name, err)
+			return newJSONRPCErrorResponse(req.ID, ErrCodeInternal, errMsg, nil), nil
+		}
+		return normalizeToolExecutionErrorResult(result, err), nil
 	}
 
 	return result, nil
+}
+
+func isExceptionalToolError(err error) bool {
+	return stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded)
+}
+
+func normalizeToolExecutionErrorResult(result *CallToolResult, err error) *CallToolResult {
+	if result == nil {
+		return NewErrorResult(err.Error())
+	}
+
+	result.IsError = true
+	if len(result.Content) == 0 {
+		result.Content = []Content{NewTextContent(err.Error())}
+	}
+	return result
 }

--- a/manager_tools_test.go
+++ b/manager_tools_test.go
@@ -471,6 +471,82 @@ func TestToolManager_HandleCallTool(t *testing.T) {
 	assert.Equal(t, ErrCodeMethodNotFound, errorResp.Error.Code)
 }
 
+func TestToolManager_HandleCallTool_HandlerErrorBecomesErrorResult(t *testing.T) {
+	manager := newToolManager()
+
+	tool := NewMockTool("error-tool", "Always returns an error", map[string]interface{}{})
+	manager.registerTool(tool, func(ctx context.Context, req *CallToolRequest) (*CallToolResult, error) {
+		return nil, fmt.Errorf("intentional failure")
+	})
+
+	req := newJSONRPCRequest("call-error", MethodToolsCall, map[string]interface{}{
+		"name":      "error-tool",
+		"arguments": map[string]interface{}{},
+	})
+
+	result, err := manager.handleCallTool(context.Background(), req, nil)
+	require.NoError(t, err)
+
+	callResult, ok := result.(*CallToolResult)
+	require.True(t, ok, "Expected *CallToolResult but got %T", result)
+	assert.True(t, callResult.IsError)
+	require.Len(t, callResult.Content, 1)
+
+	textContent, ok := callResult.Content[0].(TextContent)
+	require.True(t, ok, "Expected TextContent but got %T", callResult.Content[0])
+	assert.Equal(t, "intentional failure", textContent.Text)
+}
+
+func TestToolManager_HandleCallTool_HandlerErrorPreservesReturnedResult(t *testing.T) {
+	manager := newToolManager()
+
+	tool := NewMockTool("partial-tool", "Returns partial content before failing", map[string]interface{}{})
+	manager.registerTool(tool, func(ctx context.Context, req *CallToolRequest) (*CallToolResult, error) {
+		return &CallToolResult{
+			Content: []Content{NewTextContent("partial output")},
+		}, fmt.Errorf("stream interrupted")
+	})
+
+	req := newJSONRPCRequest("call-partial", MethodToolsCall, map[string]interface{}{
+		"name":      "partial-tool",
+		"arguments": map[string]interface{}{},
+	})
+
+	result, err := manager.handleCallTool(context.Background(), req, nil)
+	require.NoError(t, err)
+
+	callResult, ok := result.(*CallToolResult)
+	require.True(t, ok, "Expected *CallToolResult but got %T", result)
+	assert.True(t, callResult.IsError)
+	require.Len(t, callResult.Content, 1)
+
+	textContent, ok := callResult.Content[0].(TextContent)
+	require.True(t, ok, "Expected TextContent but got %T", callResult.Content[0])
+	assert.Equal(t, "partial output", textContent.Text)
+}
+
+func TestToolManager_HandleCallTool_ContextErrorsRemainProtocolErrors(t *testing.T) {
+	manager := newToolManager()
+
+	tool := NewMockTool("timeout-tool", "Returns context timeout", map[string]interface{}{})
+	manager.registerTool(tool, func(ctx context.Context, req *CallToolRequest) (*CallToolResult, error) {
+		return nil, context.DeadlineExceeded
+	})
+
+	req := newJSONRPCRequest("call-timeout", MethodToolsCall, map[string]interface{}{
+		"name":      "timeout-tool",
+		"arguments": map[string]interface{}{},
+	})
+
+	result, err := manager.handleCallTool(context.Background(), req, nil)
+	require.NoError(t, err)
+
+	errorResp, ok := result.(*JSONRPCError)
+	require.True(t, ok, "Expected *JSONRPCError but got %T", result)
+	assert.Equal(t, ErrCodeInternal, errorResp.Error.Code)
+	assert.Contains(t, errorResp.Error.Message, "context deadline exceeded")
+}
+
 func TestToolManager_ServerInfoInContext(t *testing.T) {
 	// Create a tool manager
 	manager := newToolManager()

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -124,10 +124,13 @@ func TestMiddlewareErrorHandling(t *testing.T) {
 	errorMiddleware := func(next HandlerFunc) HandlerFunc {
 		return func(ctx context.Context, req *JSONRPCRequest) (JSONRPCMessage, error) {
 			result, err := next(ctx, req)
-			// Check if result is an error response
+			// Check both protocol errors and tool execution errors.
 			if errResp, ok := result.(*JSONRPCError); ok {
 				errorResponseCaptured = true
 				_ = errResp // Use errResp to avoid unused variable warning
+			}
+			if toolResp, ok := result.(*CallToolResult); ok && toolResp.IsError {
+				errorResponseCaptured = true
 			}
 			return result, err
 		}
@@ -165,11 +168,11 @@ func TestMiddlewareErrorHandling(t *testing.T) {
 	// Execute request
 	result, err := handler.handleRequest(ctx, req, session)
 
-	// Should not return error (errors are converted to JSON-RPC error responses)
+	// Should not return error (tool execution errors are converted to CallToolResult.IsError).
 	assert.NoError(t, err)
-	// Should return an error response
-	assert.IsType(t, &JSONRPCError{}, result)
-	// Middleware should have detected the error response
+	toolResult, ok := result.(*CallToolResult)
+	require.True(t, ok, "Expected *CallToolResult but got %T", result)
+	assert.True(t, toolResult.IsError)
 	assert.True(t, errorResponseCaptured)
 }
 


### PR DESCRIPTION
## Summary by Sourcery

将工具处理器（handler）的失败报告为 CallToolResult 错误，而不是 JSON-RPC 协议错误，并更新测试和示例以体现新的错误传播行为。

Bug Fixes（错误修复）:
- 确保工具执行错误通过 `CallToolResult.IsError` 及其相应内容暴露出来，而不是被转换为 JSON-RPC 内部错误。
- 当处理器同时返回结果和错误时，保留部分工具结果，将该结果标记为错误，而不是丢弃已有内容。
- 将上下文取消（context cancellation）和截止时间超时（deadline）相关错误继续保留为 JSON-RPC 协议错误，而不是工具级错误。

Enhancements（增强）:
- 引入工具执行错误的规范化（normalization）工具，并将与上下文相关的失败归类为异常的工具错误。
- 更新中间件，使其在捕获错误响应时能够识别 JSON-RPC 错误和 `CallToolResult` 的错误结果。

Documentation（文档）:
- 在 README 中的工具调用示例里，记录需要检查 `CallToolResult.IsError` 的要求。

Tests（测试）:
- 为工具管理器的错误规范化添加单元测试，包括处理器失败、部分结果以及上下文超时等情况。
- 更新端到端（end-to-end）和集成测试，断言业务逻辑错误应作为 `CallToolResult` 错误返回，而不是 RPC 错误。
- 调整中间件测试，通过 `CallToolResult.IsError` 来验证错误检测逻辑。

Chores（杂项）:
- 更新示例工具和客户端，使用新的辅助方法和 `IsError` 标记来构造并处理错误类型的 `CallToolResult`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Report tool handler failures as CallToolResult errors instead of JSON-RPC protocol errors, and update tests and examples to reflect the new error propagation behavior.

Bug Fixes:
- Ensure tool execution errors are surfaced via CallToolResult.IsError with appropriate content instead of being converted into JSON-RPC internal errors.
- Preserve partial tool results when handlers return both a result and an error, marking the result as an error without discarding existing content.
- Keep context cancellation and deadline errors as JSON-RPC protocol errors rather than tool-level errors.

Enhancements:
- Introduce normalization utilities for tool execution errors and classify context-related failures as exceptional tool errors.
- Update middleware to recognize both JSON-RPC errors and CallToolResult error results when capturing error responses.

Documentation:
- Document the need to check CallToolResult.IsError in README tool invocation examples.

Tests:
- Add unit tests for tool manager error normalization, including handler failures, partial results, and context timeouts.
- Update end-to-end and integration tests to assert that business logic errors are returned as CallToolResult errors instead of RPC errors.
- Adjust middleware tests to verify error detection via CallToolResult.IsError.

Chores:
- Update example tools and clients to construct and handle error CallToolResults using the new helper and IsError flag.

</details>