### PR TITLE
fix(sse-client): respond to server-initiated ping with empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## 0.0.12 (2026-03-27)
+## 0.0.13 (2026-03-27)
 
 ### Fixes
 
 - fix(sse-client): respond to server-initiated `ping` with empty JSON-RPC result (MCP utilities/ping; gateway keepalive compatibility)
+
+## 0.0.12 (2026-01-14)
+
+### Features
+
+- feat: add SessionPubSub interface for cross-node session routing (#96)
 
 ## 0.0.11 (2025-12-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.12 (2026-03-27)
+
+### Fixes
+
+- fix(sse-client): respond to server-initiated `ping` with empty JSON-RPC result (MCP utilities/ping; gateway keepalive compatibility)
+
 ## 0.0.11 (2025-12-09)
 
 ### Fixes

--- a/sse_client.go
+++ b/sse_client.go
@@ -403,12 +403,25 @@ func (t *sseClientTransport) handleIncomingRequest(data string) {
 
 	// Handle different types of requests.
 	switch request.Method {
+	case MethodPing:
+		t.handlePingRequest(&request)
 	case MethodRootsList:
 		t.handleRootsListRequest(&request)
 	default:
 		// Send method not found error.
 		t.sendErrorResponse(&request, ErrCodeMethodNotFound, fmt.Sprintf("Method not found: %s", request.Method))
 	}
+}
+
+// handlePingRequest handles ping requests from the server (MCP utilities/ping).
+// The receiver MUST respond promptly with an empty result object.
+func (t *sseClientTransport) handlePingRequest(request *JSONRPCRequest) {
+	response := &JSONRPCResponse{
+		JSONRPC: JSONRPCVersion,
+		ID:      request.ID,
+		Result:  struct{}{},
+	}
+	t.sendResponseMessage(response)
 }
 
 // handleRootsListRequest handles roots/list requests from the server.

--- a/sse_client_test.go
+++ b/sse_client_test.go
@@ -7,11 +7,15 @@
 package mcp
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestWithServiceName_SSETransport tests that WithServiceName option correctly configures
@@ -152,4 +156,38 @@ func TestWithHTTPHeaders_SSETransport(t *testing.T) {
 	// Verify headers are correctly set in SSE transport
 	assert.Equal(t, "Bearer test-token", sseTransport.httpHeaders.Get("Authorization"), "Authorization header should be set in SSE transport")
 	assert.Equal(t, "test-value", sseTransport.httpHeaders.Get("X-Custom"), "X-Custom header should be set in SSE transport")
+}
+
+// TestSSEClientTransport_handleIncomingRequest_Ping verifies that a server-initiated
+// ping receives an empty JSON-RPC result on the message POST endpoint (MCP ping spec).
+func TestSSEClientTransport_handleIncomingRequest_Ping(t *testing.T) {
+	var receivedBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		receivedBody = b
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	endpoint, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	tr := &sseClientTransport{
+		endpoint:       endpoint,
+		httpClient:     ts.Client(),
+		httpReqHandler: NewDefaultHTTPReqHandler(),
+	}
+
+	pingData := `{"jsonrpc":"2.0","id":"ping-req-1","method":"ping"}`
+	tr.handleIncomingRequest(pingData)
+
+	require.NotEmpty(t, receivedBody)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(receivedBody, &resp))
+	assert.Equal(t, "2.0", resp["jsonrpc"])
+	assert.Equal(t, "ping-req-1", resp["id"])
+	result, ok := resp["result"].(map[string]interface{})
+	require.True(t, ok, "result should be a JSON object")
+	assert.Empty(t, result)
 }


### PR DESCRIPTION
Handle MCP utilities/ping on the SSE message POST path so gateways that send keepalive pings receive JSON-RPC result {} per spec. Add unit test with httptest.