### PR TITLE
fix(streamable-client): make Close() synchronously terminate GET SSE

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -8,9 +8,14 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -341,5 +346,310 @@ func TestHTTPBeforeRequestError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Expected error from HTTPBeforeRequest, got nil")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Close() contract: streamable HTTP transport
+//
+// Regression coverage for the synchronous-Close behavior of the streamable
+// HTTP client transport. Historically, Client.Close() returned as soon as it
+// canceled the GET SSE context, without waiting for the background SSE
+// goroutine to exit or closing the in-flight response body. The ctx-cancel
+// had to propagate through http.Transport to break the blocking
+// bufio.Scanner.Scan() -> resp.Body.Read(), which on CI could stall long
+// enough to cause server shutdown paths (httptest.Server.Close() in
+// trpc-agent-go#1721) to hang.
+//
+// The tests below pin down the post-fix contract:
+//   1. When Client.Close() returns, the GET SSE goroutine has exited.
+//   2. Close() returns regardless of whether the server has produced any SSE
+//      traffic (resp.Body.Close() drives the wake-up, not ctx propagation).
+//   3. Close() right after Initialize() does not leak goroutines even when
+//      racing with Initialize's `go establishGetSSEConnection(ctx)` spawn.
+// ----------------------------------------------------------------------------
+
+// sseHoldingServer is a minimal MCP-like HTTP server used by the Close()
+// regression tests. It does not reuse trpc-mcp-go's own server
+// implementation so that the contract being exercised is purely the
+// client's Close() behavior.
+type sseHoldingServer struct {
+	sessionID     string
+	activeSSE     atomic.Int32
+	handlerExited chan struct{}
+	exitedOnce    atomic.Bool
+	// handlerTick is how long the SSE handler blocks between event writes
+	// WITHOUT checking r.Context(). This models realistic MCP event
+	// producers (slow upstream / DB / LLM token stream) that cannot be
+	// interrupted mid-work.
+	handlerTick time.Duration
+}
+
+func newSSEHoldingServer() *sseHoldingServer {
+	return &sseHoldingServer{
+		sessionID:     "regression-session-1",
+		handlerExited: make(chan struct{}),
+		handlerTick:   50 * time.Millisecond,
+	}
+}
+
+func (s *sseHoldingServer) markExited() {
+	if s.exitedOnce.CompareAndSwap(false, true) {
+		close(s.handlerExited)
+	}
+}
+
+func (s *sseHoldingServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.handlePost(w, r)
+	case http.MethodGet:
+		s.handleGetSSE(w, r)
+	case http.MethodDelete:
+		w.WriteHeader(http.StatusOK)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *sseHoldingServer) handlePost(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Mcp-Session-Id", s.sessionID)
+
+	buf := make([]byte, 4096)
+	n, _ := r.Body.Read(buf)
+	body := string(buf[:n])
+
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case strings.Contains(body, `"method":"initialize"`):
+		id := extractJSONRPCID(body)
+		resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{`+
+			`"protocolVersion":"2025-03-26",`+
+			`"capabilities":{"tools":{}},`+
+			`"serverInfo":{"name":"regression-server","version":"0.0.1"}}}`, id)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	case strings.Contains(body, `"method":"notifications/initialized"`):
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		id := extractJSONRPCID(body)
+		resp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":{}}`, id)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(resp))
+	}
+}
+
+// handleGetSSE opens an SSE stream and holds it. Between writes it sleeps
+// for handlerTick WITHOUT watching r.Context() — this is the "ctx-insensitive
+// work unit" that historically kept the server handler alive past
+// Client.Close() and caused httptest.Server.Close() to block.
+func (s *sseHoldingServer) handleGetSSE(w http.ResponseWriter, r *http.Request) {
+	s.activeSSE.Add(1)
+	defer s.activeSSE.Add(-1)
+	defer s.markExited()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
+	for {
+		time.Sleep(s.handlerTick)
+
+		select {
+		case <-r.Context().Done():
+			return
+		default:
+		}
+
+		if _, err := w.Write([]byte(": ping\n\n")); err != nil {
+			return
+		}
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+}
+
+// extractJSONRPCID pulls the "id" field out of a JSON-RPC envelope so that
+// sseHoldingServer.handlePost can echo it back in its response.
+func extractJSONRPCID(body string) string {
+	idx := strings.Index(body, `"id":`)
+	if idx < 0 {
+		return `1`
+	}
+	rest := body[idx+len(`"id":`):]
+	end := strings.IndexAny(rest, ",}")
+	if end < 0 {
+		return `1`
+	}
+	return strings.TrimSpace(rest[:end])
+}
+
+// countGoroutinesMatching returns the number of goroutines whose stack trace
+// contains the given substring. Used to detect SSE goroutine leaks after
+// Client.Close().
+func countGoroutinesMatching(substr string) int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), substr)
+}
+
+// waitFor polls cond every 10ms until it returns true or the timeout
+// elapses. Returns true if cond became true in time.
+func waitFor(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+// TestClient_Close_IsSynchronous asserts that when Client.Close() returns,
+// the GET SSE goroutine has already exited. Pre-fix this was always false:
+// the goroutine outlived Close() by whatever time it took the http.Transport
+// to propagate ctx cancellation into the blocked read.
+func TestClient_Close_IsSynchronous(t *testing.T) {
+	handler := newSSEHoldingServer()
+	handler.handlerTick = 500 * time.Millisecond
+	ts := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		ts.CloseClientConnections()
+		ts.Close()
+	})
+
+	c, err := NewClient(ts.URL, Implementation{
+		Name:    "regression-client",
+		Version: "0.0.1",
+	}, WithClientGetSSEEnabled(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = c.Initialize(ctx, &InitializeRequest{})
+	require.NoError(t, err)
+
+	if !waitFor(3*time.Second, func() bool { return handler.activeSSE.Load() >= 1 }) {
+		t.Fatalf("precondition failed: GET SSE handler never became active")
+	}
+	before := countGoroutinesMatching("handleGetSSEEvents")
+	t.Logf("precondition ok: activeSSE=%d, client SSE goroutines=%d",
+		handler.activeSSE.Load(), before)
+	require.GreaterOrEqual(t, before, 1, "expected >=1 client SSE goroutine before Close")
+
+	closeStart := time.Now()
+	require.NoError(t, c.Close())
+	t.Logf("Client.Close() returned in %v", time.Since(closeStart))
+
+	// Contract: when Close returns, the client-side goroutine has exited.
+	if n := countGoroutinesMatching("handleGetSSEEvents"); n != 0 {
+		buf := make([]byte, 1<<20)
+		nb := runtime.Stack(buf, true)
+		t.Errorf("Close contract violated: %d client SSE goroutine(s) still running "+
+			"after Close() returned; Close() must synchronously join them.\n"+
+			"Full stacks:\n%s", n, buf[:nb])
+	}
+}
+
+// TestClient_Close_DoesNotWaitForServerTraffic asserts that Close() returns
+// quickly even when the server produces no SSE traffic. Pre-fix, close()
+// only sent a ctx.cancel that had to traverse http.Transport to break the
+// read; post-fix, close() calls resp.Body.Close() directly so the read
+// returns immediately with an error.
+func TestClient_Close_DoesNotWaitForServerTraffic(t *testing.T) {
+	handler := newSSEHoldingServer()
+	// Server sends nothing for a long time after the initial 200 OK.
+	handler.handlerTick = 30 * time.Second
+	ts := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		ts.CloseClientConnections()
+		ts.Close()
+	})
+
+	c, err := NewClient(ts.URL, Implementation{
+		Name:    "regression-client",
+		Version: "0.0.1",
+	}, WithClientGetSSEEnabled(true))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = c.Initialize(ctx, &InitializeRequest{})
+	require.NoError(t, err)
+	if !waitFor(3*time.Second, func() bool { return handler.activeSSE.Load() >= 1 }) {
+		t.Fatalf("precondition failed: GET SSE handler never became active")
+	}
+
+	// Close must return essentially immediately — body.Close() wakes up the
+	// blocking Read, the goroutine exits, WaitGroup unblocks Close().
+	budget := 250 * time.Millisecond
+	closeStart := time.Now()
+	require.NoError(t, c.Close())
+	closeDur := time.Since(closeStart)
+	t.Logf("Client.Close() returned in %v (budget=%v, server tick=%v)",
+		closeDur, budget, handler.handlerTick)
+
+	if closeDur >= budget {
+		t.Errorf("Close took %v, exceeding budget %v while server was quiet. "+
+			"This indicates Close() is waiting on ctx-cancellation to "+
+			"propagate through http.Transport rather than directly closing "+
+			"resp.Body", closeDur, budget)
+	}
+}
+
+// TestClient_Close_RightAfterInitialize covers the race between Close() and
+// Initialize's background `go establishGetSSEConnection(ctx)`. If Close()
+// were to return before that goroutine registered itself with sseWg, a
+// leaked SSE goroutine would appear on the runtime stack. The `closed`
+// guard in establishGetSSE prevents this.
+func TestClient_Close_RightAfterInitialize(t *testing.T) {
+	handler := newSSEHoldingServer()
+	handler.handlerTick = 100 * time.Millisecond
+	ts := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		ts.CloseClientConnections()
+		ts.Close()
+	})
+
+	// A handful of iterations is enough to hit the race on most machines;
+	// a regression usually leaks at least one goroutine per run.
+	const iterations = 50
+	for i := 0; i < iterations; i++ {
+		c, err := NewClient(ts.URL, Implementation{
+			Name:    "regression-client",
+			Version: "0.0.1",
+		}, WithClientGetSSEEnabled(true))
+		require.NoErrorf(t, err, "iter %d: NewClient", i)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_, err = c.Initialize(ctx, &InitializeRequest{})
+		if err != nil {
+			cancel()
+			t.Fatalf("iter %d: Initialize: %v", i, err)
+		}
+		// Deliberately do NOT wait for the background GET SSE goroutine to
+		// make progress: we want to race against it.
+		if err := c.Close(); err != nil {
+			cancel()
+			t.Fatalf("iter %d: Close: %v", i, err)
+		}
+		cancel()
+	}
+
+	// Give any leaked goroutine a chance to surface on the stack.
+	time.Sleep(100 * time.Millisecond)
+
+	if n := countGoroutinesMatching("handleGetSSEEvents"); n != 0 {
+		buf := make([]byte, 1<<20)
+		nb := runtime.Stack(buf, true)
+		t.Errorf("after %d tight Initialize/Close cycles, %d handleGetSSEEvents "+
+			"goroutine(s) remain on the stack. A late-spawn race is leaking "+
+			"SSE goroutines past Close().\nFull stacks:\n%s",
+			iterations, n, buf[:nb])
 	}
 }

--- a/streamable_client.go
+++ b/streamable_client.go
@@ -60,8 +60,29 @@ type streamableHTTPClientTransport struct {
 		active bool
 		ctx    context.Context
 		cancel context.CancelFunc
+		// body is the response body of the currently active GET SSE HTTP
+		// response. It is set from inside connectGetSSE once the response is
+		// available and is closed by close() to unblock the blocking
+		// bufio.Scanner read in handleGetSSEEvents, rather than waiting for
+		// the context cancellation to propagate through the HTTP transport.
+		body io.Closer
+		// closed becomes true after close() has been called. It prevents a
+		// late establishGetSSE invocation (e.g. the goroutine spawned by
+		// Initialize via `go establishGetSSEConnection`) from starting a new
+		// SSE connection after the caller has already requested shutdown.
+		// Without this guard, Close()'s sseWg.Wait() could return before
+		// such a late spawn registers itself with the WaitGroup, leaking a
+		// goroutine past Close().
+		closed bool
 		mutex  sync.Mutex
 	}
+
+	// sseWg tracks the GET SSE goroutine spawned by establishGetSSE so that
+	// close() can synchronously wait for it to exit. Without this, close()
+	// returned while the goroutine (and the server-side handler it held
+	// open) was still alive, creating a time-window during which
+	// httptest.Server.Close() / real server shutdown could block.
+	sseWg sync.WaitGroup
 
 	// Notification handlers mutex
 	handlersMutex sync.RWMutex
@@ -579,17 +600,55 @@ func (t *streamableHTTPClientTransport) sendResponse(ctx context.Context, resp *
 	return fmt.Errorf("client transport does not support sending responses")
 }
 
-// Close closes the transport connection
+// Close closes the transport connection.
+//
+// This method is synchronous: when it returns, the GET SSE goroutine has
+// exited, the underlying HTTP response body has been closed, and no further
+// notification handlers will be invoked. Callers that shut down a server
+// immediately after Close() (e.g. httptest.Server.Close() in tests, or
+// graceful server shutdown in production) can rely on in-flight SSE
+// connections having been released by the client side.
 func (t *streamableHTTPClientTransport) close() error {
-	// close GET SSE connection
+	// Snapshot the body/cancel under the mutex, then release it *before*
+	// Wait()-ing. The spawned SSE goroutine's defer re-acquires the same
+	// mutex to flip `active = false`, so holding it across Wait() would
+	// dead-lock.
 	t.getSSEConn.mutex.Lock()
-	if t.getSSEConn.active && t.getSSEConn.cancel != nil {
-		t.getSSEConn.cancel()
+	// Set closed first so that any establishGetSSE call that wins the lock
+	// after us will refuse to spawn a new goroutine.
+	t.getSSEConn.closed = true
+	cancel := t.getSSEConn.cancel
+	body := t.getSSEConn.body
+	if t.getSSEConn.active {
 		t.getSSEConn.active = false
 	}
+	// Clear the body reference so we don't try to close it twice if close()
+	// is called again.
+	t.getSSEConn.body = nil
 	t.getSSEConn.mutex.Unlock()
 
-	// Clear notification handlers
+	// Cancel the SSE context first. On its own this is not sufficient: the
+	// goroutine is blocked in bufio.Scanner.Scan() -> resp.Body.Read(), and
+	// ctx cancellation only reaches the read via the http.Transport's
+	// connection-close path, which has an observable (and in CI sometimes
+	// unbounded) delay.
+	if cancel != nil {
+		cancel()
+	}
+
+	// Forcefully close the response body so the blocking Read returns
+	// immediately with an error, letting the goroutine exit without waiting
+	// for the transport-level cancellation traversal.
+	if body != nil {
+		_ = body.Close()
+	}
+
+	// Wait for the goroutine to actually finish. After this point the
+	// caller is guaranteed that no SSE work is still in flight on this
+	// transport.
+	t.sseWg.Wait()
+
+	// Clear notification handlers.
 	t.handlersMutex.Lock()
 	t.notificationHandlers = make(map[string]NotificationHandler)
 	t.handlersMutex.Unlock()
@@ -613,6 +672,16 @@ func (t *streamableHTTPClientTransport) establishGetSSE(parentCtx context.Contex
 	t.getSSEConn.mutex.Lock()
 	defer t.getSSEConn.mutex.Unlock()
 
+	// If the transport has already been closed, do not start a new GET SSE
+	// connection. This handles the race where Initialize's background
+	// `go establishGetSSEConnection(ctx)` reaches this point *after* the
+	// caller has already invoked Client.Close(): without this guard, we
+	// would spawn a goroutine that close()'s sseWg.Wait() could not have
+	// waited on.
+	if t.getSSEConn.closed {
+		return
+	}
+
 	// If there's already an active connection, cancel the old one
 	if t.getSSEConn.active && t.getSSEConn.cancel != nil {
 		t.getSSEConn.cancel()
@@ -622,16 +691,27 @@ func (t *streamableHTTPClientTransport) establishGetSSE(parentCtx context.Contex
 	ctx, cancel := context.WithCancel(icontext.WithoutCancel(parentCtx))
 	t.getSSEConn.ctx = ctx
 	t.getSSEConn.cancel = cancel
+	// A previous attempt's body (if any) must be cleared; close() already
+	// takes ownership of closing it if this is called during shutdown.
+	t.getSSEConn.body = nil
 
 	// Mark as active
 	t.getSSEConn.active = true
 
+	// Register with the WaitGroup *before* spawning so close() cannot race
+	// past sseWg.Wait() before this goroutine registers itself.
+	t.sseWg.Add(1)
+
 	// Release lock and establish connection in a separate goroutine
 	go func() {
+		defer t.sseWg.Done()
 		// Reset connection state when function exits
 		defer func() {
 			t.getSSEConn.mutex.Lock()
 			t.getSSEConn.active = false
+			// Clear the body reference; by the time we reach here,
+			// connectGetSSE's own defer has already closed the body.
+			t.getSSEConn.body = nil
 			t.getSSEConn.mutex.Unlock()
 		}()
 
@@ -687,6 +767,14 @@ func (t *streamableHTTPClientTransport) connectGetSSE(ctx context.Context) error
 		return fmt.Errorf("GET SSE connection request failed: %w", err)
 	}
 	defer resp.Body.Close()
+
+	// Register the body so close() can forcefully close it to unblock
+	// handleGetSSEEvents' scanner.Scan(). Doing this *before* the status
+	// check means even a non-200 response path is cleanly shut down if
+	// close() races with it.
+	t.getSSEConn.mutex.Lock()
+	t.getSSEConn.body = resp.Body
+	t.getSSEConn.mutex.Unlock()
 
 	// Check response status
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
`Client.Close()` returned before the GET SSE goroutine actually exited: it
only cancelled the ctx, leaving `scanner.Scan()` blocked until the cancel
propagated through `http.Transport`. Under CI load this window stalled
downstream server shutdown — the symptom behind trpc-agent-go#1721.

Fix: close `resp.Body` directly, `sync.WaitGroup`-join the SSE goroutine,
and guard `establishGetSSE` against late spawns from `Initialize`.

Same pattern as #93, extended to the streamable HTTP transport.

Regression tests in `client_test.go` (`TestClient_Close_*`).
