### PR TITLE
fix(tools): normalize integer arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,36 @@ func main() {
 }
 ```
 
+### Tool Argument Runtime Types
+
+When a handler reads raw values from `req.Params.Arguments`, the runtime Go type is derived from the
+registered tool schema:
+
+| Tool option | Schema type | Handler value type |
+|-------------|-------------|--------------------|
+| `WithString` | `string` | `string` |
+| `WithNumber` | `number` | `float64` |
+| `WithInteger` | `integer` | `int` |
+| `WithBoolean` | `boolean` | `bool` |
+| `WithObject` | `object` | `map[string]interface{}` |
+| `WithArray` | `array` | `[]interface{}` |
+
+JSON-RPC params are decoded into `map[string]interface{}`, so JSON numbers initially arrive as
+`float64`. trpc-mcp-go normalizes fields declared as `integer` in the tool input schema to Go `int`
+before invoking the handler, including integer fields inside schema-defined objects and arrays.
+Fields declared as `number` remain `float64`.
+
+Handlers that need to support older trpc-mcp-go versions can temporarily accept both forms:
+
+```go
+switch v := req.Params.Arguments["page"].(type) {
+case int:
+	page = v
+case float64:
+	page = int(v)
+}
+```
+
 **Client:**
 ```go
 func main() {

--- a/examples/transport-modes/sse-legacy/server/main.go
+++ b/examples/transport-modes/sse-legacy/server/main.go
@@ -218,8 +218,8 @@ func handleLargeResponse(ctx context.Context, req *mcp.CallToolRequest) (*mcp.Ca
 	// Extract size parameter (default 10KB).
 	size := 10
 	if sizeArg, ok := req.Params.Arguments["size"]; ok {
-		if sizeFloat, ok := sizeArg.(float64); ok {
-			size = int(sizeFloat)
+		if sizeInt, ok := sizeArg.(int); ok {
+			size = sizeInt
 		}
 	}
 

--- a/manager_tools.go
+++ b/manager_tools.go
@@ -239,7 +239,7 @@ func (m *toolManager) handleCallTool(
 			errMsg := fmt.Sprintf("%v: arguments must be an object, got %T", mcpErrors.ErrInvalidParams, args)
 			return newJSONRPCErrorResponse(req.ID, ErrCodeInvalidParams, errMsg, nil), nil
 		}
-		params.Arguments = argsMap
+		params.Arguments = normalizeToolArguments(argsMap, registeredTool.Tool.InputSchema)
 	}
 
 	toolReq.Params = params

--- a/manager_tools_test.go
+++ b/manager_tools_test.go
@@ -35,6 +35,8 @@ func NewMockTool(name, description string, toolSchema map[string]interface{}) *T
 							opts = append(opts, WithString(paramName))
 						case "number":
 							opts = append(opts, WithNumber(paramName))
+						case "integer":
+							opts = append(opts, WithInteger(paramName))
 						case "boolean":
 							opts = append(opts, WithBoolean(paramName))
 						}
@@ -469,6 +471,59 @@ func TestToolManager_HandleCallTool(t *testing.T) {
 	errorResp, ok := result.(*JSONRPCError)
 	assert.True(t, ok, "Expected *JSONRPCError but got %T", result)
 	assert.Equal(t, ErrCodeMethodNotFound, errorResp.Error.Code)
+}
+
+func TestToolManager_HandleCallTool_NormalizesIntegerArguments(t *testing.T) {
+	manager := newToolManager()
+
+	tool := NewTool(
+		"pagination-tool",
+		WithInteger("page"),
+		WithNumber("score"),
+		WithObject("pager", Properties(openapi3.Schemas{
+			"page_size": openapi3.NewSchemaRef("", openapi3.NewIntegerSchema()),
+		})),
+		WithArray("ids", Items(openapi3.NewIntegerSchema())),
+	)
+
+	var captured map[string]interface{}
+	manager.registerTool(tool, func(ctx context.Context, req *CallToolRequest) (*CallToolResult, error) {
+		captured = req.Params.Arguments
+		return NewTextResult("ok"), nil
+	})
+
+	req := newJSONRPCRequest("call-integer", MethodToolsCall, map[string]interface{}{
+		"name": "pagination-tool",
+		"arguments": map[string]interface{}{
+			"page":    float64(2),
+			"score":   float64(1.5),
+			"pager":   map[string]interface{}{"page_size": float64(20)},
+			"ids":     []interface{}{float64(1), float64(2)},
+			"unknown": float64(3),
+		},
+	})
+
+	result, err := manager.handleCallTool(context.Background(), req, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, captured)
+
+	assert.Equal(t, 2, captured["page"])
+	assert.IsType(t, 0, captured["page"])
+	assert.Equal(t, float64(1.5), captured["score"])
+
+	pager, ok := captured["pager"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 20, pager["page_size"])
+	assert.IsType(t, 0, pager["page_size"])
+
+	ids, ok := captured["ids"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, ids, 2)
+	assert.Equal(t, 1, ids[0])
+	assert.Equal(t, 2, ids[1])
+
+	assert.Equal(t, float64(3), captured["unknown"])
 }
 
 func TestToolManager_HandleCallTool_HandlerErrorBecomesErrorResult(t *testing.T) {

--- a/tool_arguments.go
+++ b/tool_arguments.go
@@ -1,0 +1,179 @@
+// Tencent is pleased to support the open source community by making trpc-mcp-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-mcp-go is licensed under the Apache License Version 2.0.
+
+package mcp
+
+import (
+	"encoding/json"
+	"math"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+const maxSafeJSONInteger = 1<<53 - 1
+
+func normalizeToolArguments(arguments map[string]interface{}, inputSchema *openapi3.Schema) map[string]interface{} {
+	if len(arguments) == 0 || inputSchema == nil {
+		return arguments
+	}
+
+	normalized := make(map[string]interface{}, len(arguments))
+	for name, value := range arguments {
+		normalized[name] = value
+	}
+
+	normalizeObjectProperties(normalized, inputSchema)
+	return normalized
+}
+
+func normalizeArgumentValue(value interface{}, schemaRef *openapi3.SchemaRef) interface{} {
+	if value == nil || schemaRef == nil || schemaRef.Value == nil {
+		return value
+	}
+
+	schema := schemaRef.Value
+	if schema.Type.Includes(openapi3.TypeInteger) {
+		if intValue, ok := convertIntegerArgument(value); ok {
+			return intValue
+		}
+		return value
+	}
+	if schema.Type.Includes(openapi3.TypeArray) || schema.Items != nil {
+		return normalizeArrayArgument(value, schema.Items)
+	}
+	if schema.Type.Includes(openapi3.TypeObject) || len(schema.Properties) > 0 || schema.AdditionalProperties.Schema != nil {
+		return normalizeObjectArgument(value, schema)
+	}
+
+	return value
+}
+
+func normalizeArrayArgument(value interface{}, itemSchema *openapi3.SchemaRef) interface{} {
+	items, ok := value.([]interface{})
+	if !ok {
+		return value
+	}
+
+	normalized := make([]interface{}, len(items))
+	for i, item := range items {
+		normalized[i] = normalizeArgumentValue(item, itemSchema)
+	}
+	return normalized
+}
+
+func normalizeObjectArgument(value interface{}, schema *openapi3.Schema) interface{} {
+	objectValue, ok := value.(map[string]interface{})
+	if !ok {
+		return value
+	}
+
+	normalized := make(map[string]interface{}, len(objectValue))
+	for name, propertyValue := range objectValue {
+		normalized[name] = propertyValue
+	}
+	normalizeObjectProperties(normalized, schema)
+	return normalized
+}
+
+func normalizeObjectProperties(arguments map[string]interface{}, schema *openapi3.Schema) {
+	if schema == nil {
+		return
+	}
+
+	for name, propertySchema := range schema.Properties {
+		value, ok := arguments[name]
+		if !ok {
+			continue
+		}
+		arguments[name] = normalizeArgumentValue(value, propertySchema)
+	}
+
+	additionalSchema := schema.AdditionalProperties.Schema
+	if additionalSchema == nil {
+		return
+	}
+	for name, value := range arguments {
+		if _, ok := schema.Properties[name]; ok {
+			continue
+		}
+		arguments[name] = normalizeArgumentValue(value, additionalSchema)
+	}
+}
+
+func convertIntegerArgument(value interface{}) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int8:
+		return int(v), true
+	case int16:
+		return int(v), true
+	case int32:
+		return int(v), true
+	case int64:
+		if !integerFitsInt(v) {
+			return 0, false
+		}
+		return int(v), true
+	case uint:
+		if uint64(v) > uint64(math.MaxInt) {
+			return 0, false
+		}
+		return int(v), true
+	case uint8:
+		return int(v), true
+	case uint16:
+		return int(v), true
+	case uint32:
+		if uint64(v) > uint64(math.MaxInt) {
+			return 0, false
+		}
+		return int(v), true
+	case uint64:
+		if v > uint64(math.MaxInt) {
+			return 0, false
+		}
+		return int(v), true
+	case float32:
+		return convertFloatInteger(float64(v))
+	case float64:
+		return convertFloatInteger(v)
+	case json.Number:
+		if intValue, err := v.Int64(); err == nil {
+			if !integerFitsInt(intValue) {
+				return 0, false
+			}
+			return int(intValue), true
+		}
+		floatValue, err := v.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return convertFloatInteger(floatValue)
+	default:
+		return 0, false
+	}
+}
+
+func convertFloatInteger(value float64) (int, bool) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, false
+	}
+	if value != math.Trunc(value) {
+		return 0, false
+	}
+	if value < float64(math.MinInt) || value > float64(math.MaxInt) {
+		return 0, false
+	}
+	if value < -maxSafeJSONInteger || value > maxSafeJSONInteger {
+		return 0, false
+	}
+	return int(value), true
+}
+
+func integerFitsInt(value int64) bool {
+	return value >= int64(math.MinInt) && value <= int64(math.MaxInt)
+}

--- a/tool_arguments_test.go
+++ b/tool_arguments_test.go
@@ -1,0 +1,42 @@
+// Tencent is pleased to support the open source community by making trpc-mcp-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-mcp-go is licensed under the Apache License Version 2.0.
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeToolArguments_IntegerConversionEdges(t *testing.T) {
+	inputSchema := openapi3.NewObjectSchema()
+	inputSchema.Properties = openapi3.Schemas{
+		"whole":    openapi3.NewSchemaRef("", openapi3.NewIntegerSchema()),
+		"fraction": openapi3.NewSchemaRef("", openapi3.NewIntegerSchema()),
+		"unsafe":   openapi3.NewSchemaRef("", openapi3.NewIntegerSchema()),
+		"number":   openapi3.NewSchemaRef("", openapi3.NewFloat64Schema()),
+	}
+
+	unsafeInteger := float64(maxSafeJSONInteger) + 1
+	arguments := map[string]interface{}{
+		"whole":    float64(42),
+		"fraction": float64(1.25),
+		"unsafe":   unsafeInteger,
+		"number":   float64(7),
+	}
+
+	normalized := normalizeToolArguments(arguments, inputSchema)
+
+	assert.Equal(t, 42, normalized["whole"])
+	assert.IsType(t, 0, normalized["whole"])
+	assert.Equal(t, float64(1.25), normalized["fraction"])
+	assert.Equal(t, unsafeInteger, normalized["unsafe"])
+	assert.Equal(t, float64(7), normalized["number"])
+
+	assert.Equal(t, float64(42), arguments["whole"])
+}


### PR DESCRIPTION
## Summary

本 PR 在调用工具 handler 前，根据已注册工具的 `InputSchema` 对 arguments 做归一化：

- schema 为 `integer` 的字段会转换为 Go `int`
- schema 为 `number` 的字段保持 `float64`
- schema 为 `string` 的字段保持 `string`
- schema 为 `boolean` 的字段保持 `bool`
- schema 为 `object` / `array` 的字段保持原结构，并递归处理其中声明为 `integer` 的子字段
- schema 未声明的字段保持原始反序列化结果

## Problem

用户反馈通过 `mcp.WithInteger()` 注册工具参数后，在工具 handler 中从`req.Params.Arguments` 取出的实际类型是 `float64`，而不是预期的整数类型。

问题发生在 JSON-RPC 请求解析阶段，Go 标准库在反序列化到 `interface{}` 时，会把 JSON number 默认解成 `float64`，` tools/call` 之前直接把 `arguments` 作为 `map[string]interface{}` 传给 handler，因此 schema 中声明为 `integer` 的参数也会以 `float64` 暴露给用户。

### 兼容性影响

**对存量用户有潜在影响**，假设用户之前通过 `WithInteger("page")` 注册参数，但在 handler 中按旧行为读取，如：

```go
page, ok := req.Params.Arguments["page"].(float64)
```

升级后该断言会失败。新行为应改为：

```go
page, ok := req.Params.Arguments["page"].(int)
```

如果用户需要兼容新旧版本，可以临时同时支持两种类型：

```go
switch v := req.Params.Arguments["page"].(type) {
case int:
    page = v
case float64:
    page = int(v)
}
```

## Tests

```bash
GOCACHE=/data/tmp/go-build go test -count=1 ./...
GOCACHE=/data/tmp/go-build go vet ./...
```
