### PR TITLE
stdio: clean up process groups on close

### DIFF
--- a/stdio_process_other.go
+++ b/stdio_process_other.go
@@ -1,0 +1,42 @@
+//go:build !unix
+
+// Tencent is pleased to support the open source community by making trpc-mcp-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-mcp-go is licensed under the Apache License Version 2.0.
+
+package mcp
+
+import (
+	"os"
+	"os/exec"
+)
+
+func configureStdioProcess(cmd *exec.Cmd) {}
+
+func stdioProcessGroupID(cmd *exec.Cmd) int {
+	return 0
+}
+
+func stdioDescendantProcessGroupIDs(cmd *exec.Cmd) []int {
+	return nil
+}
+
+func signalStdioProcess(cmd *exec.Cmd, pgid int, signal os.Signal) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Signal(signal)
+}
+
+func killStdioProcess(cmd *exec.Cmd, pgid int) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}
+
+func killStdioProcessGroups(pgids []int) error {
+	return nil
+}

--- a/stdio_process_unix.go
+++ b/stdio_process_unix.go
@@ -1,0 +1,170 @@
+//go:build unix
+
+// Tencent is pleased to support the open source community by making trpc-mcp-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-mcp-go is licensed under the Apache License Version 2.0.
+
+package mcp
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+type stdioProcEntry struct {
+	pid  int
+	ppid int
+	pgid int
+}
+
+func configureStdioProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func stdioProcessGroupID(cmd *exec.Cmd) int {
+	if cmd == nil || cmd.Process == nil {
+		return 0
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		return 0
+	}
+	return pgid
+}
+
+func stdioDescendantProcessGroupIDs(cmd *exec.Cmd) []int {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	entries := readStdioProcEntries()
+	children := make(map[int][]stdioProcEntry)
+	for _, entry := range entries {
+		children[entry.ppid] = append(children[entry.ppid], entry)
+	}
+
+	seenPID := map[int]bool{cmd.Process.Pid: true}
+	seenPGID := make(map[int]bool)
+	queue := []int{cmd.Process.Pid}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		for _, child := range children[parent] {
+			if seenPID[child.pid] {
+				continue
+			}
+			seenPID[child.pid] = true
+			queue = append(queue, child.pid)
+			if child.pgid > 0 {
+				seenPGID[child.pgid] = true
+			}
+		}
+	}
+
+	pgids := make([]int, 0, len(seenPGID))
+	for pgid := range seenPGID {
+		pgids = append(pgids, pgid)
+	}
+	return pgids
+}
+
+func signalStdioProcess(cmd *exec.Cmd, pgid int, signal os.Signal) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	sig, ok := signal.(syscall.Signal)
+	if !ok {
+		return cmd.Process.Signal(signal)
+	}
+	if pgid > 0 {
+		if err := killProcessGroup(pgid, sig); err == nil {
+			return nil
+		}
+	}
+	return cmd.Process.Signal(signal)
+}
+
+func killStdioProcess(cmd *exec.Cmd, pgid int) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	if pgid > 0 {
+		if err := killProcessGroup(pgid, syscall.SIGKILL); err == nil {
+			return nil
+		}
+	}
+	return cmd.Process.Kill()
+}
+
+func killStdioProcessGroups(pgids []int) error {
+	var errs []error
+	seen := make(map[int]bool)
+	for _, pgid := range pgids {
+		if pgid <= 0 || seen[pgid] {
+			continue
+		}
+		seen[pgid] = true
+		if err := killProcessGroup(pgid, syscall.SIGKILL); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func killProcessGroup(pgid int, sig syscall.Signal) error {
+	err := syscall.Kill(-pgid, sig)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
+}
+
+func readStdioProcEntries() []stdioProcEntry {
+	files, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	entries := make([]stdioProcEntry, 0, len(files))
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(file.Name())
+		if err != nil {
+			continue
+		}
+		data, err := os.ReadFile("/proc/" + file.Name() + "/stat")
+		if err != nil {
+			continue
+		}
+		if entry, ok := parseStdioProcStat(pid, string(data)); ok {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
+func parseStdioProcStat(pid int, stat string) (stdioProcEntry, bool) {
+	end := strings.LastIndex(stat, ") ")
+	if end < 0 || end+2 >= len(stat) {
+		return stdioProcEntry{}, false
+	}
+	fields := strings.Fields(stat[end+2:])
+	if len(fields) < 3 {
+		return stdioProcEntry{}, false
+	}
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return stdioProcEntry{}, false
+	}
+	pgid, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return stdioProcEntry{}, false
+	}
+	return stdioProcEntry{pid: pid, ppid: ppid, pgid: pgid}, true
+}

--- a/transport_stdio.go
+++ b/transport_stdio.go
@@ -47,6 +47,8 @@ type stdioClientTransport struct {
 	stdin   io.WriteCloser
 	stdout  io.ReadCloser
 	stderr  io.ReadCloser
+	done    chan error
+	pgid    int
 
 	encoder   *json.Encoder
 	decoder   *json.Decoder
@@ -124,6 +126,7 @@ func (t *stdioClientTransport) startProcess() error {
 
 	// Create command.
 	cmd := exec.CommandContext(t.ctx, t.serverParams.Command, t.serverParams.Args...)
+	configureStdioProcess(cmd)
 
 	// Set working directory if specified.
 	if t.serverParams.WorkingDir != "" {
@@ -170,6 +173,8 @@ func (t *stdioClientTransport) startProcess() error {
 	t.stdin = stdin
 	t.stdout = stdout
 	t.stderr = stderr
+	t.done = make(chan error, 1)
+	t.pgid = stdioProcessGroupID(cmd)
 
 	// Create JSON encoder/decoder.
 	t.encoder = json.NewEncoder(stdin)
@@ -563,6 +568,10 @@ func (t *stdioClientTransport) processWatcher() {
 	}
 
 	err := t.process.Wait()
+	if t.done != nil {
+		t.done <- err
+		close(t.done)
+	}
 	if !t.closed.Load() {
 		if err != nil {
 			t.logger.Debugf("Process exited with error: %v", err)
@@ -596,6 +605,11 @@ func (t *stdioClientTransport) close() error {
 
 	var errs []error
 
+	var childPGIDs []int
+	if t.process != nil && t.process.Process != nil {
+		childPGIDs = stdioDescendantProcessGroupIDs(t.process)
+	}
+
 	// Cancel context first.
 	t.cancel()
 
@@ -620,27 +634,34 @@ func (t *stdioClientTransport) close() error {
 
 	// Terminate process gracefully.
 	if t.process != nil && t.process.Process != nil {
-		// First try SIGTERM
-		if err := t.process.Process.Signal(os.Interrupt); err != nil {
-			t.logger.Debugf("Failed to send SIGTERM: %v", err)
+		if err := signalStdioProcess(t.process, t.pgid, os.Interrupt); err != nil {
+			t.logger.Debugf("Failed to interrupt stdio process: %v", err)
 		}
 
 		// Wait a bit for graceful shutdown.
-		done := make(chan struct{})
-		go func() {
-			t.process.Wait()
-			close(done)
-		}()
-
 		select {
-		case <-done:
+		case <-t.done:
 			t.logger.Debugf("Process terminated gracefully")
+			if err := killStdioProcessGroups(childPGIDs); err != nil {
+				errs = append(errs, fmt.Errorf("failed to clean child groups: %w", err))
+			}
+			if err := killStdioProcess(t.process, t.pgid); err != nil {
+				errs = append(errs, fmt.Errorf("failed to clean process group: %w", err))
+			}
 		case <-time.After(5 * time.Second):
 			// Force kill.
-			if err := t.process.Process.Kill(); err != nil {
+			if err := killStdioProcessGroups(childPGIDs); err != nil {
+				errs = append(errs, fmt.Errorf("failed to kill child groups: %w", err))
+			}
+			if err := killStdioProcess(t.process, t.pgid); err != nil {
 				errs = append(errs, fmt.Errorf("failed to kill process: %w", err))
 			} else {
 				t.logger.Debugf("Process force-killed")
+			}
+			select {
+			case <-t.done:
+			case <-time.After(time.Second):
+				errs = append(errs, fmt.Errorf("process did not exit after kill"))
 			}
 		}
 	}

--- a/transport_stdio_unix_test.go
+++ b/transport_stdio_unix_test.go
@@ -1,0 +1,106 @@
+//go:build unix
+
+// Tencent is pleased to support the open source community by making trpc-mcp-go available.
+//
+// Copyright (C) 2025 Tencent.  All rights reserved.
+//
+// trpc-mcp-go is licensed under the Apache License Version 2.0.
+
+package mcp
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStdioTransportCloseKillsBackgroundChild(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	require.NoError(t, err)
+
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	script := "sleep 60 & echo $! > " + pidFile + "; wait"
+	childPID := startStdioProcessTree(t, sh, script, pidFile)
+
+	require.Eventually(t, func() bool {
+		return !processExists(childPID)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestStdioTransportCloseKillsDescendantProcessGroup(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	require.NoError(t, err)
+
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	script := "TRPC_MCP_STDIO_PG_CHILD=1 " +
+		"TRPC_MCP_STDIO_PG_CHILD_PID_FILE=" + pidFile +
+		" " + os.Args[0] +
+		" -test.run=TestStdioProcessGroupChildHelper" +
+		" & wait"
+	childPID := startStdioProcessTree(t, sh, script, pidFile)
+
+	require.Eventually(t, func() bool {
+		return !processExists(childPID)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func startStdioProcessTree(
+	t *testing.T,
+	sh string,
+	script string,
+	pidFile string,
+) int {
+	t.Helper()
+
+	transport := newStdioClientTransport(StdioServerParameters{
+		Command: sh,
+		Args:    []string{"-c", script},
+	})
+
+	require.NoError(t, transport.startProcess())
+
+	var childPID int
+	require.Eventually(t, func() bool {
+		raw, readErr := os.ReadFile(pidFile)
+		if readErr != nil {
+			return false
+		}
+		pid, parseErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+		if parseErr != nil {
+			return false
+		}
+		childPID = pid
+		return processExists(pid)
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, transport.close())
+	return childPID
+}
+
+func TestStdioProcessGroupChildHelper(t *testing.T) {
+	if os.Getenv("TRPC_MCP_STDIO_PG_CHILD") != "1" {
+		return
+	}
+	require.NoError(t, syscall.Setpgid(0, 0))
+	pidFile := os.Getenv("TRPC_MCP_STDIO_PG_CHILD_PID_FILE")
+	require.NotEmpty(t, pidFile)
+	err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0o600)
+	require.NoError(t, err)
+	time.Sleep(time.Minute)
+	os.Exit(0)
+}
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil
+}


### PR DESCRIPTION
## Summary

- start stdio MCP servers in their own process group on Unix
- signal and kill the whole process group during transport close
- avoid double Wait races by reusing the process watcher result
- add a Unix regression test for background child cleanup

## Validation

- `go test . -run 'TestStdioTransportCloseKillsBackgroundChild|TestStdio' -count=1`\n- `go test ./...`