### PR TITLE
feat: add JSON Schema property constraint options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.0.17 (2026-07-20)
+
+### Features
+
+- feat: add stdio to streamable proxy
+- feat: add JSON Schema property constraint options
+
+### Fixes
+
+- fix(stdio): clean up process groups on close
+
 ## 0.0.16 (2026-05-15)
 
 ### Fixes

--- a/mcp_tools.go
+++ b/mcp_tools.go
@@ -383,6 +383,52 @@ func Enum(values ...string) PropertyOption {
 	}
 }
 
+// MinLength sets the minimum length of a string property.
+func MinLength(min int) PropertyOption {
+	return func(s *openapi3.Schema) {
+		s.MinLength = uint64(min)
+	}
+}
+
+// MaxLength sets the maximum length of a string property.
+func MaxLength(max int) PropertyOption {
+	return func(s *openapi3.Schema) {
+		val := uint64(max)
+		s.MaxLength = &val
+	}
+}
+
+// Pattern sets the regular expression constraint of a string property.
+func Pattern(pattern string) PropertyOption {
+	return func(s *openapi3.Schema) {
+		s.Pattern = pattern
+	}
+}
+
+// Min sets the minimum value of a numeric property.
+func Min(min float64) PropertyOption {
+	return func(s *openapi3.Schema) {
+		val := min
+		s.Min = &val
+	}
+}
+
+// Max sets the maximum value of a numeric property.
+func Max(max float64) PropertyOption {
+	return func(s *openapi3.Schema) {
+		val := max
+		s.Max = &val
+	}
+}
+
+// MultipleOf sets the multiple-of constraint of a numeric property.
+func MultipleOf(multiple float64) PropertyOption {
+	return func(s *openapi3.Schema) {
+		val := multiple
+		s.MultipleOf = &val
+	}
+}
+
 // Properties adds properties to the tool's input schema.
 func Properties(props openapi3.Schemas) PropertyOption {
 	return func(s *openapi3.Schema) {

--- a/mcp_tools_test.go
+++ b/mcp_tools_test.go
@@ -178,6 +178,51 @@ func TestMockTool(t *testing.T) {
 	assert.Equal(t, customResult, result)
 }
 
+func TestPropertyConstraints(t *testing.T) {
+	tool := NewTool("constrained",
+		WithString("name",
+			MinLength(2),
+			MaxLength(20),
+			Pattern(`^[a-z]+$`),
+		),
+		WithNumber("ratio",
+			Min(0.5),
+			Max(9.5),
+			MultipleOf(0.5),
+		),
+		WithInteger("count",
+			Min(1),
+			Max(10),
+		),
+		WithNumber("zero",
+			Min(0),
+			Max(0),
+		),
+	)
+
+	name := tool.InputSchema.Properties["name"].Value
+	assert.Equal(t, uint64(2), name.MinLength)
+	assert.Equal(t, uint64(20), *name.MaxLength)
+	assert.Equal(t, `^[a-z]+$`, name.Pattern)
+
+	ratio := tool.InputSchema.Properties["ratio"].Value
+	assert.Equal(t, 0.5, *ratio.Min)
+	assert.Equal(t, 9.5, *ratio.Max)
+	assert.Equal(t, 0.5, *ratio.MultipleOf)
+
+	count := tool.InputSchema.Properties["count"].Value
+	assert.Equal(t, float64(1), *count.Min)
+	assert.Equal(t, float64(10), *count.Max)
+
+	zero := tool.InputSchema.Properties["zero"].Value
+	assert.Equal(t, float64(0), *zero.Min)
+	assert.Equal(t, float64(0), *zero.Max)
+	data, err := json.Marshal(zero)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"minimum":0`)
+	assert.Contains(t, string(data), `"maximum":0`)
+}
+
 func TestParseCallToolResult(t *testing.T) {
 	testCases := []struct {
 		name                 string


### PR DESCRIPTION
Adds JSON Schema property constraint options for strings and numbers, including length, pattern, range, and multiple-of constraints. Includes tests for schema mappings and zero-value serialization.