### PR TITLE
feat: support custom tool schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,36 @@ mcp.WithInputStruct[Input](mcp.WithRefStyle())
 mcp.WithOutputStruct[Output](mcp.WithInlineStyle())
 ```
 
+**Custom Schemas:**
+
+When a schema comes from configuration or another schema source, pass the
+complete OpenAPI schema directly instead of rebuilding it property by property:
+
+```go
+var inputSchema openapi3.Schema
+if err := json.Unmarshal(schemaJSON, &inputSchema); err != nil {
+    return err
+}
+
+configuredTool := mcp.NewTool(
+    "configured_tool",
+    mcp.WithDescription("Tool whose input schema comes from configuration"),
+    mcp.WithInputSchema(&inputSchema),
+)
+```
+
+`WithInputSchema` replaces the default input schema, while `WithOutputSchema`
+sets the structured output schema. These options change the schema advertised
+to MCP clients; the handler must still parse, validate, and process compatible
+arguments and results.
+
+The root input schema must have `type: "object"`, as required by MCP. Tool
+options are applied in order: property options such as `WithString` can extend
+a custom input schema, while a later `WithInputSchema` replaces earlier input
+schema changes. The tool retains the provided schema pointer, so treat it as
+immutable after `NewTool` returns; sharing the pointer is safe only while it
+remains immutable.
+
 **Benefits:**
 - 🛡️ **Type Safety**: Compile-time type checking and automatic validation
 - 📋 **Rich Schemas**: Auto-generated OpenAPI schemas with descriptions, enums, defaults

--- a/mcp_tools.go
+++ b/mcp_tools.go
@@ -194,10 +194,61 @@ func NewTool(
 	return tool
 }
 
+// ensureInputSchemaProperties makes property-building options safe to apply
+// after options that replace the complete input schema. It intentionally does
+// not change the schema type; callers are responsible for supplying the object
+// root required by MCP.
+func ensureInputSchemaProperties(t *Tool) {
+	if t.InputSchema == nil {
+		t.InputSchema = openapi3.NewObjectSchema()
+	}
+	if t.InputSchema.Properties == nil {
+		t.InputSchema.Properties = make(openapi3.Schemas)
+	}
+}
+
 // WithDescription common option function
 func WithDescription(description string) ToolOption {
 	return func(t *Tool) {
 		t.Description = description
+	}
+}
+
+// WithInputSchema sets a custom input schema for the tool.
+// It replaces the default input schema. A nil schema is ignored so the tool
+// keeps its existing input schema.
+//
+// MCP requires the root input schema to have type "object"; this option does
+// not validate or coerce the supplied schema. Options are applied in order, so
+// later property-building options augment the supplied schema, while a later
+// WithInputSchema replaces earlier schema changes.
+//
+// The tool retains the supplied pointer. Treat the schema as immutable after
+// NewTool returns to avoid cross-tool mutation and concurrent access races.
+//
+// The schema describes the arguments exposed to MCP clients. Tool handlers
+// must still parse and validate those arguments consistently with the schema.
+func WithInputSchema(inputSchema *openapi3.Schema) ToolOption {
+	return func(t *Tool) {
+		if inputSchema != nil {
+			t.InputSchema = inputSchema
+		}
+	}
+}
+
+// WithOutputSchema sets a custom output schema for the tool.
+// It replaces the existing output schema. A nil schema is ignored.
+//
+// The tool retains the supplied pointer. Treat the schema as immutable after
+// NewTool returns to avoid cross-tool mutation and concurrent access races.
+//
+// The schema describes the structured content exposed to MCP clients. Tool
+// handlers must still return structured content that conforms to the schema.
+func WithOutputSchema(outputSchema *openapi3.Schema) ToolOption {
+	return func(t *Tool) {
+		if outputSchema != nil {
+			t.OutputSchema = outputSchema
+		}
 	}
 }
 
@@ -261,6 +312,7 @@ func WithToolAnnotations(annotations *ToolAnnotations) ToolOption {
 // WithString adds a string parameter to the tool's input schema
 func WithString(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
+		ensureInputSchemaProperties(t)
 		schema := &openapi3.Schema{
 			Type: &openapi3.Types{openapi3.TypeString},
 		}
@@ -278,6 +330,7 @@ func WithString(name string, opts ...PropertyOption) ToolOption {
 // WithNumber adds a number parameter to the tool's input schema
 func WithNumber(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
+		ensureInputSchemaProperties(t)
 		schema := &openapi3.Schema{
 			Type: &openapi3.Types{openapi3.TypeNumber},
 		}
@@ -295,6 +348,7 @@ func WithNumber(name string, opts ...PropertyOption) ToolOption {
 // WithInteger adds an integer parameter to the tool's input schema
 func WithInteger(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
+		ensureInputSchemaProperties(t)
 		schema := &openapi3.Schema{
 			Type: &openapi3.Types{openapi3.TypeInteger},
 		}
@@ -312,6 +366,7 @@ func WithInteger(name string, opts ...PropertyOption) ToolOption {
 // WithBoolean adds a boolean parameter to the tool's input schema
 func WithBoolean(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
+		ensureInputSchemaProperties(t)
 		schema := &openapi3.Schema{
 			Type: &openapi3.Types{openapi3.TypeBoolean},
 		}
@@ -329,6 +384,7 @@ func WithBoolean(name string, opts ...PropertyOption) ToolOption {
 // WithObject adds an object parameter to the tool's input schema.
 func WithObject(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
+		ensureInputSchemaProperties(t)
 		schema := &openapi3.Schema{
 			Type:       &openapi3.Types{openapi3.TypeObject},
 			Properties: make(openapi3.Schemas),
@@ -439,6 +495,7 @@ func Properties(props openapi3.Schemas) PropertyOption {
 // WithArray adds an array to the tool's input schema.
 func WithArray(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
+		ensureInputSchemaProperties(t)
 		schema := &openapi3.Schema{
 			Type: &openapi3.Types{openapi3.TypeArray},
 		}

--- a/mcp_tools_test.go
+++ b/mcp_tools_test.go
@@ -11,7 +11,9 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MockTool is a mock tool implementation for testing
@@ -769,6 +771,116 @@ type TestSchemaStruct struct {
 	Name  string `json:"name"`
 	Age   int    `json:"age"`
 	Email string `json:"email,omitempty"`
+}
+
+func TestWithInputSchema(t *testing.T) {
+	customSchema := openapi3.NewObjectSchema().
+		WithProperty("query", openapi3.NewStringSchema().WithPattern(`^[a-z]+$`)).
+		WithRequired([]string{"query"})
+
+	tool := NewTool("test-tool",
+		WithString("replaced"),
+		WithInputSchema(customSchema),
+	)
+
+	assert.Same(t, customSchema, tool.InputSchema)
+	assert.Contains(t, tool.InputSchema.Properties, "query")
+	assert.NotContains(t, tool.InputSchema.Properties, "replaced")
+
+	t.Run("nil keeps existing schema", func(t *testing.T) {
+		tool := NewTool("test-tool",
+			WithInputSchema(customSchema),
+			WithInputSchema(nil),
+		)
+
+		assert.Same(t, customSchema, tool.InputSchema)
+	})
+
+	t.Run("property option augments configuration schema without properties", func(t *testing.T) {
+		var configuredSchema openapi3.Schema
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"object"}`), &configuredSchema))
+
+		tool := NewTool("test-tool",
+			WithInputSchema(&configuredSchema),
+			WithString("extra", Required()),
+			WithNumber("ratio"),
+			WithInteger("count"),
+			WithBoolean("enabled"),
+			WithObject("metadata"),
+			WithArray("items"),
+		)
+
+		assert.Same(t, &configuredSchema, tool.InputSchema)
+		assert.Len(t, tool.InputSchema.Properties, 6)
+		for _, name := range []string{"extra", "ratio", "count", "enabled", "metadata", "items"} {
+			assert.Contains(t, tool.InputSchema.Properties, name)
+		}
+		assert.Contains(t, tool.InputSchema.Required, "extra")
+	})
+}
+
+func TestWithOutputSchema(t *testing.T) {
+	customSchema := openapi3.NewObjectSchema().
+		WithProperty("result", openapi3.NewStringSchema()).
+		WithRequired([]string{"result"})
+
+	tool := NewTool("test-tool", WithOutputSchema(customSchema))
+
+	assert.Same(t, customSchema, tool.OutputSchema)
+	assert.Contains(t, tool.OutputSchema.Properties, "result")
+
+	t.Run("nil keeps existing schema", func(t *testing.T) {
+		tool := NewTool("test-tool",
+			WithOutputSchema(customSchema),
+			WithOutputSchema(nil),
+		)
+
+		assert.Same(t, customSchema, tool.OutputSchema)
+	})
+}
+
+func TestCustomSchemasMarshal(t *testing.T) {
+	inputSchema := openapi3.NewObjectSchema().WithRequired([]string{"query"})
+	inputSchema.Extensions = map[string]any{
+		"$defs": map[string]any{
+			"Query": map[string]any{
+				"type":    "string",
+				"pattern": `^[a-z]+$`,
+			},
+		},
+	}
+	inputSchema.Properties["query"] = openapi3.NewSchemaRef("#/$defs/Query", nil)
+	outputSchema := openapi3.NewObjectSchema().
+		WithProperty("result", openapi3.NewStringSchema()).
+		WithRequired([]string{"result"})
+
+	tool := NewTool("test-tool",
+		WithInputSchema(inputSchema),
+		WithOutputSchema(outputSchema),
+	)
+	encoded, err := json.Marshal(tool)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"name": "test-tool",
+		"inputSchema": {
+			"type": "object",
+			"properties": {
+				"query": {"$ref": "#/$defs/Query"}
+			},
+			"required": ["query"],
+			"$defs": {
+				"Query": {"type": "string", "pattern": "^[a-z]+$"}
+			}
+		},
+		"outputSchema": {
+			"type": "object",
+			"properties": {
+				"result": {"type": "string"}
+			},
+			"required": ["result"]
+		}
+	}`, string(encoded))
 }
 
 // TestWithInputStruct tests WithInputStruct function


### PR DESCRIPTION
## Summary

- Add `WithInputSchema` and `WithOutputSchema` for injecting complete OpenAPI schemas, including configuration-driven schemas.
- Allow existing property options to safely extend custom input schemas with nil `properties`.
- Add documentation and tests for replacement, option ordering, nil handling, and JSON serialization.

These options only change the schemas advertised to MCP clients; handlers remain responsible for compatible parsing and validation.